### PR TITLE
Fix space in column name

### DIFF
--- a/nomenclatures/ipc_descriptions/03_02_abstract_from_ipc.py
+++ b/nomenclatures/ipc_descriptions/03_02_abstract_from_ipc.py
@@ -157,7 +157,7 @@ with open(ifname, "rb") as ifile:
     dicToCsv(ofname, csv_columns, dict_data['desc'])
 
     # Create the simple ipc table
-    csv_columns = [' ipc_class_level', 'description', 'ipc_version']
+    csv_columns = ['ipc_class_level', 'description', 'ipc_version']
     ofname = '03_ipc_list.output.csv'
     dicToCsv(ofname, csv_columns, dict_data['ipc'])
 


### PR DESCRIPTION
Remove a space in a string that was causing a mismatch between what was expected and the real value of the key 'ipc_class_level'  in the script's input csv file.

Fixes #3 