### PR TITLE
Fix dict key in ipc script

### DIFF
--- a/nomenclatures/ipc_descriptions/03_02_abstract_from_ipc.py
+++ b/nomenclatures/ipc_descriptions/03_02_abstract_from_ipc.py
@@ -162,6 +162,6 @@ with open(ifname, "rb") as ifile:
     dicToCsv(ofname, csv_columns, dict_data['ipc'])
 
     # Create the hierarchy ipc table
-    csv_columns = [' ipc_class_level', 'ancestor', 'parent', 'ipc_version']
+    csv_columns = ['ipc_class_level', 'ancestor', 'parent', 'ipc_version']
     ofname = '04_ipc_hierarchy.output.csv'
     dicToCsv(ofname, csv_columns, dict_data['hrchy'])


### PR DESCRIPTION
Removes a space from the same key as #8 from the next array of keys.

Also related to #3 